### PR TITLE
OPENFED-39: Fix File URL alias status issue

### DIFF
--- a/config/install/pathauto.settings.yml
+++ b/config/install/pathauto.settings.yml
@@ -1,4 +1,5 @@
 enabled_entity_types:
+  - file
   - user
 punctuation:
   double_quotes: 0

--- a/openfed.install
+++ b/openfed.install
@@ -16,3 +16,24 @@ function openfed_update_101203() {
   $config = \Drupal::service('config.factory')->getEditable('system.theme');
   $config->set('admin', $default_admin_theme)->save();
 }
+
+/**
+ * Adds "File" entity type to the "enabled_entity_types" property in the
+ * "pathauto.settings.yml" configuration to fix File URL alias status issue.
+ */
+function openfed_update_101204() {
+  // Loads pathauto settings configuration.
+  $config = \Drupal::configFactory()->getEditable('pathauto.settings');
+  // Gets the pathauto enabled entity types.
+  $enabled_entity_types = $config->get('enabled_entity_types');
+  // If the File entity type is already enabled we do nothing.
+  if (in_array('file', $enabled_entity_types)) {
+    return;
+  }
+  // Adds the File entity to the array of enabled entity types.
+  $enabled_entity_types[] = 'file';
+  sort($enabled_entity_types);
+  // We update the configuration.
+  $config->set('enabled_entity_types', $enabled_entity_types);
+  $config->save();
+}


### PR DESCRIPTION
### Fixes:

- Enable file entity type in property "enabled_entity_types" of pathauto.settings.yml configuration.

### Test:

- Run `drush updb`
- Run `drush cex`
- Make sure the configuration property "enabled_entity_types" in "pathauto.settings.yml" contains the entry "file"