### PR TITLE
Issue #65: Enable translation of content type before assigning permissions

### DIFF
--- a/modules/openfed_features/openfed_administration/openfed_administration.module
+++ b/modules/openfed_features/openfed_administration/openfed_administration.module
@@ -95,6 +95,9 @@ function openfed_administration_node_type_add_form_submit(array &$form, FormStat
   // Add content moderation to the new content type.
   \Drupal::service('openfed_administration.content_type_manager')->addWorkflowToBundle($bundle->id());
 
+  // Enable translation for the new content type.
+  \Drupal::service('openfed_administration.content_type_manager')->enableTranslation($bundle->id());
+
   // Add Permissions to the roles.
   \Drupal::service('openfed_administration.content_type_manager')->assignPermissionsToRoles($bundle->id());
 }

--- a/modules/openfed_features/openfed_administration/openfed_administration.services.yml
+++ b/modules/openfed_features/openfed_administration/openfed_administration.services.yml
@@ -1,4 +1,4 @@
 services:
   openfed_administration.content_type_manager:
     class: Drupal\openfed_administration\Service\ContentTypeManager
-    arguments: ['@entity_type.manager']
+    arguments: ['@entity_type.manager', '@content_translation.manager']

--- a/modules/openfed_features/openfed_administration/src/Service/ContentTypeManager.php
+++ b/modules/openfed_features/openfed_administration/src/Service/ContentTypeManager.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\openfed_administration\Service;
 
+use Drupal\content_translation\ContentTranslationManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -17,13 +18,24 @@ class ContentTypeManager {
   protected $entityTypeManager;
 
   /**
+   * The content translation manager.
+   *
+   * @var \Drupal\content_translation\ContentTranslationManagerInterface
+   */
+  protected $contentTranslationManager;
+
+  /**
    * Constructs a ContentTypeManager object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   *
+   * @param ContentTranslationManagerInterface $content_translation_manager
+   *   The content translation manager.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ContentTranslationManagerInterface $content_translation_manager) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->contentTranslationManager = $content_translation_manager;
   }
 
   /**
@@ -84,6 +96,16 @@ class ContentTypeManager {
       $role->save();
     }
 
+  }
+
+  /**
+   * Enables translation for a node type.
+   *
+   * @param string $content_type_name
+   *   The machine name of the content type.
+   */
+  public function enableTranslation($content_type_name) {
+    $this->contentTranslationManager->setEnabled('node', $content_type_name, TRUE);
   }
 
 }


### PR DESCRIPTION
Issue #65  

### Changes:
- Enable translation of content type before assigning permissions for translations.

### Affected Pages
- /admin/structure/types/add

### Key Affected Code
- modules/openfed_features/openfed_administration/openfed_administration.module
- modules/openfed_features/openfed_administration/openfed_administration.services.yml
- modules/openfed_features/openfed_administration/src/Service/ContentTypeManager.php

### How to test?
- Go to /admin/structure/types/add
- Give a name to the content type
- Check the "Apply the default config to the content type" option and submit the form
- Check the new content type. The settings in the Language settings tab should be as follows: Enable translation - checked, Default language - Interface text language selected for page.


