### PR TITLE
fix(multilingual): ensure field label translations use correct langcode by setting the config override language. (F2W-204)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
                 "Issue #2321071: BaseFieldOverride fails": "https://www.drupal.org/files/issues/2023-11-02/2321071-71.patch",
                 "Issue #2325899: UI fatal caused by views argument handlers no longer can provide their own default argument handling": "https://www.drupal.org/files/issues/2024-04-04/2325899-10.2.5-184.patch",
                 "Issue #2649268: Entity Field Query throws QueryException when querying all revisions and setting condition on entity reference field": "https://www.drupal.org/files/issues/2019-09-12/2649268-32.patch",
-                "Issue #2898335: Using AJAX in menu link's edit form causes database connection serialization errors": "https://www.drupal.org/files/issues/2025-02-26/2898335-10.patch"
+                "Issue #2898335: Using AJAX in menu link's edit form causes database connection serialization errors": "https://www.drupal.org/files/issues/2025-02-26/2898335-10.patch",
+                "Issue #3221375: Wrong language field labels after `drush cr` because of Drush language negotiation": "https://www.drupal.org/files/issues/2024-02-23/3221375_lost-field-labels-translations.patch"
             },
             "drupal/ckeditor": {
                 "Issue #2771837: drupalimage CKEditor plugin should not require data-entity-uuid and data-entity-type when image upload is disabled": "https://www.drupal.org/files/issues/2023-03-08/2771837-90.patch"


### PR DESCRIPTION
This fix the incorrect labels in the field_definitions records in cache_discovery bin when we create a new translation