### PR TITLE
fix(ckeditor5): auto enable CKEditor 5 Find and Replace plugin when CKEditor Find module is enabled (F2W-609)

### DIFF
--- a/includes/openfed.ckeditor5.update.inc
+++ b/includes/openfed.ckeditor5.update.inc
@@ -24,6 +24,12 @@ function _openfed_update_cke_initialize(array &$sandbox) {
       $sandbox['messages'][] = 'Enabled CKEditor 5 module.';
     }
 
+    // Enable CKEditor 5 Find and Replace plugin if CKEditor Find module is present.
+    if ($module_handler->moduleExists('ckeditor_find')) {
+      \Drupal::service('module_installer')->install(['ckeditor5_plugin_pack_find_and_replace']);
+      $sandbox['messages'][] = 'Enabled CKEditor 5 Find and Replace plugin module.';
+    }
+
     // Get all CKEditor 4 editors.
     $editor_ids = _openfed_update_cke_get_ckeditor4_editors();
 


### PR DESCRIPTION
### !! Attention

When this is merge we need to remove the manual step on [Openfed-13.6.0](https://fedictaim.atlassian.net/wiki/spaces/~5ad84f59f289712b34d35ea4/pages/20431306769/Openfed-13.6.0+-+Jan+21)